### PR TITLE
Update android_device.py

### DIFF
--- a/mobly/controllers/android_device.py
+++ b/mobly/controllers/android_device.py
@@ -54,6 +54,7 @@ CACHED_SYSTEM_PROPS = [
     'ro.build.version.codename',
     'ro.build.version.incremental',
     'ro.build.version.sdk',
+    'ro.build.version.sdk_full',
     'ro.build.product',
     'ro.build.characteristics',
     'ro.debuggable',
@@ -481,6 +482,7 @@ class BuildInfoConstants(enum.Enum):
       'ro.build.version.incremental',
   )
   BUILD_VERSION_SDK = 'build_version_sdk', 'ro.build.version.sdk'
+  BUILD_VERSION_SDK_FULL = 'build_version_sdk_full', 'ro.build.version.sdk_full'  
   BUILD_PRODUCT = 'build_product', 'ro.build.product'
   BUILD_CHARACTERISTICS = 'build_characteristics', 'ro.build.characteristics'
   DEBUGGABLE = 'debuggable', 'ro.debuggable'


### PR DESCRIPTION
android_device: add BUILD_VERSION_SDK_FULL to AndroidProperties

This is the new versioning variable for minor API bumps.